### PR TITLE
Fixed default application key

### DIFF
--- a/app/config/app.php
+++ b/app/config/app.php
@@ -65,7 +65,7 @@ return array(
     |
     */
 
-    'key' => 'YjLIKb1qK4xk4Py7hpPDnPMjUkUlpebB',
+    'key' => 'YourSecretKey!!!',
 
     /*
     |--------------------------------------------------------------------------


### PR DESCRIPTION
This allows artisan key:generate to work as well as puts it back to Laravel defaults
