### PR TITLE
Fixed incorrect method call on Ardent User object in AdminUsersController.php

### DIFF
--- a/app/controllers/admin/AdminUsersController.php
+++ b/app/controllers/admin/AdminUsersController.php
@@ -76,7 +76,7 @@ class AdminUsersController extends AdminController {
         else
         {
             // Get validation errors (see Ardent package)
-            $error = $user->getErrors()->all();
+            $error = $user->errors()->all();
 
             return Redirect::to('admin/users/create')
                 ->withInput(Input::except('password'))


### PR DESCRIPTION
As per the Ardent doccumentation (https://github.com/laravelbook/ardent#errors), line 79 of app/controllers/admin/AdminUsersController.php should read:

```
$error = $user->errors()->all();
```

instead of:

```
$error = $user->getErrors()->all(); 
```
