### PR TITLE
use just one view for two create/edit actions (prototypical mod for views/admin/users)

### DIFF
--- a/app/controllers/admin/AdminUsersController.php
+++ b/app/controllers/admin/AdminUsersController.php
@@ -67,9 +67,15 @@ class AdminUsersController extends AdminController {
 
         // Selected permissions
         $selectedPermissions = Input::old('permissions', array());
+        
+		// Title
+		$title = Lang::get('admin/users/title.create_a_new_user');
 
-        // Show the page
-        return View::make('admin/users/create', compact('roles', 'permissions', 'selectedRoles', 'selectedPermissions'));
+		// Mode
+		$mode = 'create';
+
+		// Show the page
+		return View::make('admin/users/edit', compact('roles', 'permissions', 'selectedRoles', 'selectedPermissions', 'title', 'mode'));
     }
 
     /**
@@ -137,8 +143,13 @@ class AdminUsersController extends AdminController {
         {
             $roles = $this->role->all();
             $permissions = $this->permission->all();
+
             // Show the page
-            return View::make('admin/users/edit', compact('user', 'roles', 'permissions'));
+        	$title = Lang::get('admin/users/title.user_update');;
+        	// mode
+        	$mode = 'edit'; 
+            
+        	return View::make('admin/users/edit', compact('user', 'roles', 'permissions', 'title', 'mode'));
         }
         else
         {

--- a/app/lang/en/admin/users/title.php
+++ b/app/lang/en/admin/users/title.php
@@ -3,5 +3,7 @@
 return array(
 
 	'user_management'    => 'User Management',
+	'user_update'        => 'User Update',
+	'create_a_new_user'  => 'Create a New User',
 
 );

--- a/app/views/admin/users/edit.blade.php
+++ b/app/views/admin/users/edit.blade.php
@@ -1,16 +1,13 @@
 @extends('admin/layouts.default')
 
 {{-- Web site Title --}}
-@section('title')
-User Update ::
-@parent
-@stop
+@section('title') {{ $title }} :: @parent @stop
 
 {{-- Content --}}
 @section('content')
 <div class="page-header">
 	<h3>
-		User Update
+		{{ $title }}
 
 		<div class="pull-right">
 			<a href="{{{ URL::to('admin/users') }}}" class="btn btn-small btn-inverse"><i class="icon-circle-arrow-left icon-white"></i> Back</a>
@@ -24,7 +21,7 @@ User Update ::
 </ul>
 <!-- ./ tabs -->
 
-<form class="form-horizontal" method="post" action="{{ URL::to('admin/users/' . $user->id . '/edit') }}" autocomplete="off">
+<form class="form-horizontal" method="post" action="@if (isset($user)){{ URL::to('admin/users/' . $user->id . '/edit') }}@endif" autocomplete="off">
 	<!-- CSRF Token -->
 	<input type="hidden" name="_token" value="{{{ csrf_token() }}}" />
 	<!-- ./ csrf token -->
@@ -37,7 +34,7 @@ User Update ::
 			<div class="control-group {{{ $errors->has('username') ? 'error' : '' }}}">
 				<label class="control-label" for="username">Username</label>
 				<div class="controls">
-					<input type="text" name="username" id="username" value="{{{ Input::old('username', $user->username) }}}" />
+					<input type="text" name="username" id="username" value="{{{ Input::old('username', isset($user) ? $user->username : null) }}}" />
 					{{{ $errors->first('username', '<span class="help-inline">:message</span>') }}}
 				</div>
 			</div>
@@ -47,7 +44,7 @@ User Update ::
 			<div class="control-group {{{ $errors->has('email') ? 'error' : '' }}}">
 				<label class="control-label" for="email">Email</label>
 				<div class="controls">
-					<input type="text" name="email" id="email" value="{{{ Input::old('email', $user->email) }}}" />
+					<input type="text" name="email" id="email" value="{{{ Input::old('email', isset($user) ? $user->email : null) }}}" />
 					{{{ $errors->first('email', '<span class="help-inline">:message</span>') }}}
 				</div>
 			</div>
@@ -74,13 +71,20 @@ User Update ::
 			<!-- ./ password confirm -->
 
 			<!-- Activation Status -->
-			<div class="control-group {{{ $errors->has('confirm') ? 'error' : '' }}}">
+			<div class="control-group {{{ $errors->has('activated') || $errors->has('confirm') ? 'error' : '' }}}">
 				<label class="control-label" for="confirm">Activate User?</label>
 				<div class="controls">
-					<select{{{ ($user->id === Confide::user()->id ? ' disabled="disabled"' : '') }}} name="confirm" id="confirm">
-						<option value="1"{{{ ($user->confirmed ? ' selected="selected"' : '') }}}>{{{ Lang::get('general.yes') }}}</option>
-						<option value="0"{{{ ( ! $user->confirmed ? ' selected="selected"' : '') }}}>{{{ Lang::get('general.no') }}}</option>
-					</select>
+					@if ($mode == 'create')
+						<select name="confirm" id="confirm">
+							<option value="1"{{{ (Input::old('confirm', 0) === 1 ? ' selected="selected"' : '') }}}>{{{ Lang::get('general.yes') }}}</option>
+							<option value="0"{{{ (Input::old('confirm', 0) === 0 ? ' selected="selected"' : '') }}}>{{{ Lang::get('general.no') }}}</option>
+						</select>
+					@else
+						<select{{{ ($user->id === Confide::user()->id ? ' disabled="disabled"' : '') }}} name="confirm" id="confirm">
+							<option value="1"{{{ ($user->confirmed ? ' selected="selected"' : '') }}}>{{{ Lang::get('general.yes') }}}</option>
+							<option value="0"{{{ ( ! $user->confirmed ? ' selected="selected"' : '') }}}>{{{ Lang::get('general.no') }}}</option>
+						</select>
+					@endif
 					{{{ $errors->first('confirm', '<span class="help-inline">:message</span>') }}}
 				</div>
 			</div>
@@ -88,24 +92,27 @@ User Update ::
 
 			<!-- Groups -->
 			<div class="control-group {{{ $errors->has('roles') ? 'error' : '' }}}">
-				<label class="control-label" for="roles">Roles</label>
-				<div class="controls">
-					<select name="roles[]" id="roles[]" multiple>
-						@foreach ($roles as $role)
-						<option value="{{{ $role->id }}}"{{{ ( array_search($role->id, $user->currentRoleIds()) !== false && array_search($role->id, $user->currentRoleIds()) >= 0 ? ' selected="selected"' : '') }}}>{{{ $role->name }}}</option>
-						@endforeach
+                <label class="control-label" for="roles">Roles</label>
+                <div class="controls">
+	                <select name="roles[]" id="roles[]" multiple>
+	                        @foreach ($roles as $role)
+								@if ($mode == 'create')
+	                        		<option value="{{{ $role->id }}}"{{{ ( in_array($role->id, $selectedRoles) ? ' selected="selected"' : '') }}}>{{{ $role->name }}}</option>
+	                        	@else
+									<option value="{{{ $role->id }}}"{{{ ( array_search($role->id, $user->currentRoleIds()) !== false && array_search($role->id, $user->currentRoleIds()) >= 0 ? ' selected="selected"' : '') }}}>{{{ $role->name }}}</option>
+								@endif
+	                        @endforeach
 					</select>
 
 					<span class="help-block">
 						Select a group to assign to the user, remember that a user takes on the permissions of the group they are assigned.
 					</span>
-				</div>
+            	</div>
 			</div>
 			<!-- ./ groups -->
 		</div>
 		<!-- ./ general tab -->
 
-		<!-- ./ permissions tab -->
 	</div>
 	<!-- ./ tabs content -->
 
@@ -114,7 +121,7 @@ User Update ::
 		<div class="controls">
 			<a class="btn btn-link" href="{{{ URL::to('admin/users') }}}">Cancel</a>
 			<button type="reset" class="btn">Reset</button>
-			<button type="submit" class="btn btn-success">Update User</button>
+			<button type="submit" class="btn btn-success">OK</button>
 		</div>
 	</div>
 	<!-- ./ form actions -->


### PR DESCRIPTION
The idea behind this is to save headaches when editing blade templates.
In the given example here the two files create/edit.blade.php were pretty much the same except some key places, of course.
I tried to make edit.blade.php able to also serve as the view for getCreate from AdminUsersController to eliminate the other view file.

Andrew, please review this and tell me if it works on your setup. Would be great.
I did upldate the admin/users/title language file to incorporate the page titles, too.

Tell me what you think about it, my knowledge of blade is basic so you may want to do these things diffetently a bit perhaps.

However it would be great if it was possible to achieve the general goal to use just one view for create/edit actions.
