### PR TITLE
Pass error code to response

### DIFF
--- a/app/start/global.php
+++ b/app/start/global.php
@@ -60,13 +60,13 @@ App::error(function(Exception $exception, $code)
     switch ($code)
     {
         case 403:
-            return View::make('error/403');
+            return Response::view('error/403', array(), 403);
 
         case 500:
-            return View::make('error/500');
+            return Response::view('error/500', array(), 500);
 
         default:
-            return View::make('error/404');
+            return Response::view('error/404', array(), $code);
     }
 });
 


### PR DESCRIPTION
Otherwise errors just get passed with code 200, which is bad for SEO etc.

Maybe you should consider making 500 the default, instead of 404? And perhaps return the 403/404 views, instead of errors in debug (so you can test the views easier, and 403/404 are pretty much self explainatory)
