### PR TITLE
Validation error HTML unescaped in blog create/edit validation

### DIFF
--- a/app/views/admin/blogs/create_edit.blade.php
+++ b/app/views/admin/blogs/create_edit.blade.php
@@ -23,7 +23,7 @@
                     <div class="col-md-12">
                         <label class="control-label" for="title">Post Title</label>
 						<input class="form-control" type="text" name="title" id="title" value="{{{ Input::old('title', isset($post) ? $post->title : null) }}}" />
-						{{{ $errors->first('title', '<span class="help-inline">:message</span>') }}}
+						{{ $errors->first('title', '<span class="help-inline">:message</span>') }}
 					</div>
 				</div>
 				<!-- ./ post title -->
@@ -33,7 +33,7 @@
 					<div class="col-md-12">
                         <label class="control-label" for="content">Content</label>
 						<textarea class="form-control full-width wysihtml5" name="content" value="content" rows="10">{{{ Input::old('content', isset($post) ? $post->content : null) }}}</textarea>
-						{{{ $errors->first('content', '<span class="help-inline">:message</span>') }}}
+						{{ $errors->first('content', '<span class="help-inline">:message</span>') }}
 					</div>
 				</div>
 				<!-- ./ content -->
@@ -47,7 +47,7 @@
 					<div class="col-md-12">
                         <label class="control-label" for="meta-title">Meta Title</label>
 						<input class="form-control" type="text" name="meta-title" id="meta-title" value="{{{ Input::old('meta-title', isset($post) ? $post->meta_title : null) }}}" />
-						{{{ $errors->first('meta-title', '<span class="help-inline">:message</span>') }}}
+						{{ $errors->first('meta-title', '<span class="help-inline">:message</span>') }}
 					</div>
 				</div>
 				<!-- ./ meta title -->
@@ -57,7 +57,7 @@
 					<div class="col-md-12 controls">
                         <label class="control-label" for="meta-description">Meta Description</label>
 						<input class="form-control" type="text" name="meta-description" id="meta-description" value="{{{ Input::old('meta-description', isset($post) ? $post->meta_description : null) }}}" />
-						{{{ $errors->first('meta-description', '<span class="help-inline">:message</span>') }}}
+						{{ $errors->first('meta-description', '<span class="help-inline">:message</span>') }}
 					</div>
 				</div>
 				<!-- ./ meta description -->
@@ -67,7 +67,7 @@
 					<div class="col-md-12">
                         <label class="control-label" for="meta-keywords">Meta Keywords</label>
 						<input class="form-control" type="text" name="meta-keywords" id="meta-keywords" value="{{{ Input::old('meta-keywords', isset($post) ? $post->meta_keywords : null) }}}" />
-						{{{ $errors->first('meta-keywords', '<span class="help-inline">:message</span>') }}}
+						{{ $errors->first('meta-keywords', '<span class="help-inline">:message</span>') }}
 					</div>
 				</div>
 				<!-- ./ meta keywords -->


### PR DESCRIPTION
The HTML code `<span class="help-inline">:message</span>` was escaped in `app\views\admin\blogs\create_edit.blade.php` so the error message along with the HTML code was displayed in the browser. Unescaped the string so that only the error is displayed in the browser.
