### PR TITLE
Changing leafo/lessphp to oyejorge/less.php

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,24 +22,23 @@
 		"zizaco/entrust": "dev-master",
 		"jasonlewis/basset": "dev-master",
 		"robclancy/presenter": "1.2.*",
-        "j20/php-uuid": "dev-master",
-        "bllim/datatables": "*"
+		"j20/php-uuid": "dev-master",
+        	"bllim/datatables": "*"
 	},
 	"require-dev": {
         "way/generators": "dev-master",
         "mockery/mockery": "dev-master@dev",
         "summerstreet/woodling": "0.1.*",
         "barryvdh/laravel-ide-helper": "dev-master",
-        "leafo/lessphp": "v0.4.0",
+        "oyejorge/less.php": "~1.5",
         "natxet/CssMin": "dev-master",
         "lmammino/jsmin4assetic": "1.0.*"
 	},
 	"autoload": {
 		"classmap": [
-
 			"app/commands",
 			"app/controllers",
-            "app/library",
+            		"app/library",
 			"app/models",
 			"app/presenters",
 			"app/database/migrations",


### PR DESCRIPTION
Fixing issue while using

```
php artisan basset:build
```

causing this error:

```
[Exception]
parse error: failed at `&:extend(.clearfix all);` /../../../../vendor/twbs/bootstrap/less/
mixins.less on line 643
```
