### PR TITLE
Remove deprecated flag

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -60,19 +60,17 @@ $ git clone git://github.com/andrewelkins/Laravel-4-Bootstrap-Starter-Site.git l
 ```bash
 $ cd laravel
 $ curl -s http://getcomposer.org/installer | php
-$ php composer.phar install --dev
+$ php composer.phar install
 ```
 
 #### Option 2: Composer is installed globally
 
 ```bash
 $ cd laravel
-$ composer install --dev
+$ composer install
 ```
 
 If you haven't already, you might want to make [composer be installed globally](http://andrewelkins.com/programming/php/setting-up-composer-globally-for-laravel-4/) for future ease of use.
-
-Please note the use of the `--dev` flag.
 
 Some packages used to preprocess and minify assests are required on the development environment.
 


### PR DESCRIPTION
The `--dev` flag has been officially deprecated: https://github.com/composer/composer/blob/master/CHANGELOG.md#100-alpha8-2014-01-06. All dev dependencies are installed automatically, unless `--no-dev` is provided