### PR TITLE
Ignore .env files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 /vendor
 
 # Configuration
+.env
 /app/config/local
 /app/config/staging
 /app/config/production


### PR DESCRIPTION
.env files may contain private information such as API keys thus should remain far from the CVS.
